### PR TITLE
Fix allows multiple webhooks, seperated by commas

### DIFF
--- a/src/main/java/com/betterdiscordlootlogger/BetterDiscordLootLoggerPlugin.java
+++ b/src/main/java/com/betterdiscordlootlogger/BetterDiscordLootLoggerPlugin.java
@@ -31,6 +31,8 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -404,18 +406,20 @@ public class BetterDiscordLootLoggerPlugin extends Plugin
 			return;
 		}
 
-		HttpUrl url = HttpUrl.parse(configUrl);
+		ArrayList<String> urls = new ArrayList<>(Arrays.asList(configUrl.split("\\s*,\\s*")));
 		MultipartBody.Builder requestBodyBuilder = new MultipartBody.Builder()
-			.setType(MultipartBody.FORM)
-			.addFormDataPart("payload_json", GSON.toJson(discordWebhookBody));
+				.setType(MultipartBody.FORM)
+				.addFormDataPart("payload_json", GSON.toJson(discordWebhookBody));
 
-		if (config.sendScreenshot())
-		{
-			sendWebhookWithScreenshot(url, requestBodyBuilder);
-		}
-		else
-		{
-			buildRequestAndSend(url, requestBodyBuilder);
+		for (String url : urls) {
+			HttpUrl httpUrl = HttpUrl.parse(url);
+			if (httpUrl != null) {
+				if (config.sendScreenshot()) {
+					sendWebhookWithScreenshot(httpUrl, requestBodyBuilder);
+				} else {
+					buildRequestAndSend(httpUrl, requestBodyBuilder);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request allows multiple discord webhooks to be used. Currently it is only possible to use 1 webhook at a time.

Fixes #10 and #19 

Changes Made
`ArrayList<String> urls = new ArrayList<>(Arrays.asList(configUrl.split("\\s*,\\s*")));`

This code splits the webhooks into an array
The array of urls is then looped through, and sent to each webhook.

I've tested using between 1-3 webhooks separated by commas, and all function without error.