### PR TITLE
feat: translate valuable chests from barrows into the valuable drops …

### DIFF
--- a/src/main/java/com/betterdiscordlootlogger/BetterDiscordLootLoggerPlugin.java
+++ b/src/main/java/com/betterdiscordlootlogger/BetterDiscordLootLoggerPlugin.java
@@ -79,6 +79,7 @@ public class BetterDiscordLootLoggerPlugin extends Plugin
 {
 	private static final String COLLECTION_LOG_TEXT = "New item added to your collection log: ";
 	private static final Pattern VALUABLE_DROP_PATTERN = Pattern.compile(".*Valuable drop: ([^<>]+?\\(((?:\\d+,?)+) coins\\))(?:</col>)?");
+	private static final Pattern VALUABLE_CHEST_DROP_PATTERN = Pattern.compile(".*Your chest is worth around ([^<>]+?\\(((?:\\d+,?)+) coins\\))(?:</col>)?");
 	private static final ImmutableList<String> PET_MESSAGES = ImmutableList.of("You have a funny feeling like you're being followed",
 		"You feel something weird sneaking into your backpack",
 		"You have a funny feeling like you would have been followed");
@@ -182,6 +183,12 @@ public class BetterDiscordLootLoggerPlugin extends Plugin
 		if (config.includeValuableDrops())
 		{
 			Matcher matcher = VALUABLE_DROP_PATTERN.matcher(chatMessage);
+
+			//If it does not match the valuable drop pattern then try the valuable chest drop pattern (Barrows chests)
+			if (!matcher.matches()) {
+				matcher = VALUABLE_CHEST_DROP_PATTERN.matcher(chatMessage);
+			}
+
 			if (matcher.matches())
 			{
 				int valuableDropValue = Integer.parseInt(matcher.group(2).replaceAll(",", ""));


### PR DESCRIPTION
*I will preface this by saying I am not a JAVA deveoloper so this was me trying to make the smallest change possible*

The barrows chests currently don't log valuable drops. This may also be similar to why #8 doesn't work for repeat drops (I bet collection log notifications work for raids, just not repeat drops)

- Created a pattern to match against the format of a barrows chest message "Your chest is worth around 1,123,456 coins"
- If a message doesn't match the valuable drop message, then test it against the valuable chest pattern
- If the message **does match** the chest pattern then use the same mechanism used for valuable drops
